### PR TITLE
Some exceptions can now contain details

### DIFF
--- a/arborize/exceptions.py
+++ b/arborize/exceptions.py
@@ -1,3 +1,38 @@
+def _details_iter(labels, values):
+    i = 0
+    while True:
+        label = next(labels, None)
+        try:
+            value = next(values)
+            actual_values = True
+        except StopIteration:
+            actual_values = False
+        if label:
+            yield (label, value)
+        elif actual_values:
+            yield (i, value)
+        else:
+            break
+        i += 1
+
+class ArgDetailsException(Exception):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.details = dict(_details_iter(iter(self.__class__._detail_labels), iter(args)))
+
+    def __getattr__(self, attr):
+        if attr in self.__class__._detail_labels:
+            return self.details[attr]
+        return super().__getattribute__(attr)
+
+    def __str__(self):
+        return str(self.args[0])
+
+    def __init_subclass__(cls, details=[], **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._detail_labels = details
+
+
 class ArborizeError(Exception):
     pass
 
@@ -10,13 +45,16 @@ class ModelClassError(ModelError):
 class MorphologyBuilderError(ModelError):
     pass
 
-class MechanismNotPresentError(ModelClassError):
+class MechanismNotPresentError(ArgDetailsException, ModelClassError, details=["mechanism"]):
+    pass
+
+class MechanismNotFoundError(ArgDetailsException, ModelClassError, details=["mechanism", "variant"]):
     pass
 
 class LabelNotDefinedError(ModelClassError):
     pass
 
-class SectionAttributeError(ModelClassError):
+class SectionAttributeError(ArgDetailsException, ModelClassError):
     pass
 
 class ConnectionError(ArborizeError):

--- a/docs/source/neuron_model.rst
+++ b/docs/source/neuron_model.rst
@@ -1,3 +1,7 @@
 =====================
 NeuronModel Reference
 =====================
+
+The :class:`NeuronModel <.core.NeuronModel>` class binds a set of morphologies to a set of
+section types. Each section of each morphology is labelled and the mechanisms associated
+with these labels are inserted into the mechanisms.


### PR DESCRIPTION
When inheriting from `DetailedArgException` the `details` kwarg can be given to the inheritance list and they will be used as labels for `self.args`. If less args are given the fields are filled with `None`, if more args are given they are given the index of the arg as label:

```python
class MyException(DetailedArgException, details=["origin", "cause"]):
  pass

e = MyException("Something went wrong", "here", "me")
e.cause
>>> 'me'
e.args[1]
>>> "here"
e.details["origin"]
>>> "here"

e = MyException("Something went wrong", "here")
e.cause
>>> None

e = MyException("Something went wrong", "here", "me", "extra")
e.3
>>> 'extra'
e.details["3"]
>>>  'extra'
```